### PR TITLE
Update zeroconf==0.119.0 in requirements.txt

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-zeroconf==0.122.0
+zeroconf==0.119.0
 python-osc
 openvr
 argparse


### PR DESCRIPTION
This was the latest version of zeroconf I could use without getting the `ImportError`

```
Traceback (most recent call last):
  File "C:\Users\Qbitz\Documents\GitHub\VRCThumbParamsOSC\venv\Lib\site-packages\cx_Freeze\initscripts\__startup__.py", line 124, in run
    module_init.run(name + "__main__")
  File "C:\Users\Qbitz\Documents\GitHub\VRCThumbParamsOSC\venv\Lib\site-packages\cx_Freeze\initscripts\console.py", line 16, in run
    exec(code, module_main.__dict__)
  File "main.py", line 9, in <module>
  File "C:\Users\Qbitz\Documents\GitHub\VRCThumbParamsOSC\src\osc.py", line 2, in <module>
    from tinyoscquery.queryservice import OSCQueryService
  File "C:\Users\Qbitz\Documents\GitHub\VRCThumbParamsOSC\src\tinyoscquery\queryservice.py", line 1, in <module>
    from zeroconf import ServiceInfo, Zeroconf
ImportError: dynamic module does not define module export function (PyInit_zeroconf)
```